### PR TITLE
Remove Executables Property from Gemspec

### DIFF
--- a/pageflow-progress-navigation-bar.gemspec
+++ b/pageflow-progress-navigation-bar.gemspec
@@ -10,7 +10,6 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ['lib']
 


### PR DESCRIPTION
Gem does not contain executables.