### PR TITLE
Display mobile navigation on narrow desktop browsers

### DIFF
--- a/app/assets/stylesheets/pageflow/cross_dependant_styles.css.scss
+++ b/app/assets/stylesheets/pageflow/cross_dependant_styles.css.scss
@@ -2,8 +2,17 @@ body .widget_progress_navigation_bar_present .navigation_mobile {
   .menu.index {
     right: 20px;
   }
+
   &.active .menu.index {
     right: 200px;
+  }
+
+  .parent_page {
+    right: 70px;
+  }
+
+  &.active .parent_page {
+    right: 250px;
   }
 }
 
@@ -11,11 +20,8 @@ body .widget_progress_navigation_bar_present .navigation_mobile {
   body.has_mobile_platform .widget_progress_navigation_bar_present & {
     display: block;
   }
-
-  body.has_no_mobile_platform .widget_progress_navigation_bar_present & {
-    display: none;
-  }
 }
+
 .js .widget_progress_navigation_bar_present .page .close_button {
   @include desktop {
     right: 125px;

--- a/app/assets/stylesheets/pageflow/progress_navigation_bar.css.scss
+++ b/app/assets/stylesheets/pageflow/progress_navigation_bar.css.scss
@@ -24,6 +24,16 @@ $progressbar-mobile-width: 14px;
   }
 }
 
+@mixin pageflow-progress-mobile-variant {
+  .has_mobile_platform & {
+    @content;
+  }
+
+  @include phone {
+    @content;
+  }
+}
+
 @mixin pageflow-progress-navigation-bar-transparent-background {
   &:after {
     height: 100%;
@@ -84,7 +94,7 @@ $progressbar-mobile-width: 14px;
     }
   }
 
-  .has_mobile_platform & {
+  @include pageflow-progress-mobile-variant {
     width: $progressbar-mobile-width;
     @include transition(opacity 0.4s ease 0.5s);
     opacity: 0;
@@ -96,6 +106,7 @@ $progressbar-mobile-width: 14px;
     opacity: 1;
     @include transition(opacity 0.4s ease);
   }
+
   position: absolute;
   right: 0;
   top: 0;
@@ -115,7 +126,7 @@ $progressbar-mobile-width: 14px;
     top: 35px;
     background-position: left top;
 
-    .has_mobile_platform & {
+    @include pageflow-progress-mobile-variant {
       display: none;
     }
 
@@ -202,14 +213,14 @@ $progressbar-mobile-width: 14px;
     overflow: visible;
     width: 122px;
 
-    .has_mobile_platform & {
+    @include pageflow-progress-mobile-variant {
       width: 14px;
     }
 
     .navigation_button_area {
       width: 87px;
 
-      .has_mobile_platform & {
+      @include pageflow-progress-mobile-variant {
         display: none;
       }
 
@@ -469,31 +480,27 @@ $progressbar-mobile-width: 14px;
       bottom: 0;
       right: 0;
       width: 30px;
-      .has_mobile_platform & {
-        width: $progressbar-mobile-width;
-      }
       max-height: 100%;
       overflow: hidden;
       position: absolute;
-
       @include pageflow-progress-navigation-bar-transparent-background;
 
-
+      @include pageflow-progress-mobile-variant {
+        width: $progressbar-mobile-width;
+      }
 
       ul {
         position: absolute;
         right: 8px;
         width: 14px;
-
-        .has_mobile_platform & {
-          right: 3px;
-          width: 8px;
-
-
-        }
         top: 50%;
         max-height: 100%;
         @include transform(translate(0, -50%) !important);
+
+        @include pageflow-progress-mobile-variant {
+          right: 3px;
+          width: 8px;
+        }
 
         li {
           position: relative;


### PR DESCRIPTION
The phone variant of the parent page button does not work well with
the progress navigation bar.