### PR TITLE
Decouple from overview widget

### DIFF
--- a/app/assets/javascript/pageflow/progress_navigation_bar/widget.js
+++ b/app/assets/javascript/pageflow/progress_navigation_bar/widget.js
@@ -91,11 +91,6 @@
         pageLinks.off('mouseup touchend', goToPage);
       }
 
-      function closeOverview() {
-        $('.overview').removeClass("active");
-        $('.navigation_index', that.element).removeClass("active");
-      }
-
       function hideOverlay() {
         $(overlays).addClass('hidden').removeClass('visible');
       }
@@ -105,8 +100,6 @@
           return;
         }
         hideOverlay();
-        closeOverview();
-        $('.page .content, .scroll_indicator').removeClass('hidden');
         pageflow.slides.goToById(this.getAttribute("data-link"));
         e.preventDefault();
       }

--- a/pageflow-progress-navigation-bar.gemspec
+++ b/pageflow-progress-navigation-bar.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'pageflow', '~> 0.9'
+  spec.add_runtime_dependency 'pageflow', '~> 0.10.pre'
   spec.add_runtime_dependency 'pageflow-public-i18n', '~> 1.0'
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
Overview now closes by itself when current page changes.