### PR TITLE
Prevent toggling horizontal class

### DIFF
--- a/app/assets/javascript/pageflow/progress_navigation_bar/widget.js
+++ b/app/assets/javascript/pageflow/progress_navigation_bar/widget.js
@@ -51,7 +51,7 @@
 
       this.element.addClass('js').append(overlays);
 
-      this.element.toggleClass('horizontal', useHorizontalVariant(this.element));
+      this.element.toggleClass('horizontal', !!useHorizontalVariant(this.element));
       this.element.toggleClass('vertical', !useHorizontalVariant(this.element));
 
       $('a.navigation_top', this.element).topButton();


### PR DESCRIPTION
Never pass undefined to `toggleClass` even if
`pageflow.navigationDirection` is not defined.

REDMINE-15986