### PR TITLE
Fix position of unmute button in mobile variant

### DIFF
--- a/app/assets/stylesheets/pageflow/progress_navigation_bar/themes/default/widget_margin.scss
+++ b/app/assets/stylesheets/pageflow/progress_navigation_bar/themes/default/widget_margin.scss
@@ -10,7 +10,7 @@
   margin-right: 120px;
 
   @include pageflow-progress-mobile-variant {
-    margin-right: 0;
+    margin-right: 10px;
   }
 }
 


### PR DESCRIPTION
Apply widget margin right to account for mobile variant of progress
navigation bar, just like it is already applied to the index button of
the mobile navigation.

REDMINE-15986