### PR TITLE
Prevent loading of invisible thumbnails before load event

### DIFF
--- a/app/assets/javascript/pageflow/progress_navigation_bar/widget.js
+++ b/app/assets/javascript/pageflow/progress_navigation_bar/widget.js
@@ -160,6 +160,8 @@
       pageLinks.each(function(index) {
         var handlerIn = function() {
           if (!('ontouchstart' in document.documentElement)) {
+            overlays.loadLazyImages();
+
             if (that.element.hasClass('horizontal')) {
               var offset = 204;
               var left = $(this).offset().left;

--- a/app/views/pageflow/progress_navigation_bar/widget/_page.html.erb
+++ b/app/views/pageflow/progress_navigation_bar/widget/_page.html.erb
@@ -10,6 +10,8 @@
     <hr />
     <% end %>
     <%= page.title %>
-    <div class="thumbnail is_<%= page.template %>" style="background-image: url('<%= asset_path(page.thumbnail_url(:navigation_thumbnail_large)) %>')"></div>
+    <div class="thumbnail is_<%= page.template %>">
+      <%= image_tag('', data: {src: page.thumbnail_url(:navigation_thumbnail_large)}) %>
+    </div>
   </div>
 <% end %>


### PR DESCRIPTION
Use `data-src` attribute and set `src` attribute via custom jQuery
function.

Loading thumbnails initially delays load event and makes loading
spinner stick around.

REDMINE-16290