### PR TITLE
Improve lazy loading thumbnails

### DIFF
--- a/app/views/pageflow/progress_navigation_bar/widget/_page.html.erb
+++ b/app/views/pageflow/progress_navigation_bar/widget/_page.html.erb
@@ -11,7 +11,7 @@
     <% end %>
     <%= page.title %>
     <div class="thumbnail is_<%= page.template %>">
-      <%= image_tag('', data: {src: page.thumbnail_url(:navigation_thumbnail_large)}) %>
+      <%= image_tag('', data: {src: asset_path(page.thumbnail_url(:navigation_thumbnail_large))}) %>
     </div>
   </div>
 <% end %>

--- a/pageflow-progress-navigation-bar.gemspec
+++ b/pageflow-progress-navigation-bar.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.1'
 
-  spec.add_runtime_dependency 'pageflow', ['>= 12.2.x', '< 14']
+  spec.add_runtime_dependency 'pageflow', ['>= 12.5.x', '< 14']
   spec.add_runtime_dependency 'pageflow-public-i18n', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '~> 1.0'


### PR DESCRIPTION
* Pass urls through `asset_path` to ensure digests are included in
  placeholder paths.

* Depend on Pageflow 12.5.x for custom jQuery function to lazy load
  images.

REDMINE-16290