### PR TITLE
Decrease z-index for horizontal navigation bar

### DIFF
--- a/app/assets/stylesheets/pageflow/progress_navigation_bar/horizontal.scss
+++ b/app/assets/stylesheets/pageflow/progress_navigation_bar/horizontal.scss
@@ -6,6 +6,7 @@ $thumbnail-small-width: 50px;
   left: 0;
   height: 30px;
   width: 100%;
+  z-index: 2;
 
   @include pageflow-progress-mobile-variant {
     height: $progressbar-mobile-width;


### PR DESCRIPTION
In order to not conceal links in headers of themes which add
theme-specific header navigations, decrease the z-index of the
horizontal bar variant by 1

REDMINE-16772